### PR TITLE
updated kotlin & gradle versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.1.4-2'
+    ext.kotlinVersion = '1.3.72'
 
     repositories {
         jcenter()
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2'
     }
 }
 
@@ -37,16 +37,16 @@ subprojects {
     }
 
     jacoco {
-        toolVersion = "0.7.2.201409121644"
+        toolVersion = "0.8.5"
     }
 
     jacocoTestReport {
-        executionData = files("${project.buildDir}/jacoco/test.exec")
+        // executionData = files("${project.buildDir}/jacoco/test.exec")
         reports {
-            xml.destination "${buildDir}/reports/jacoco/report.xml"
+            xml.destination file("${buildDir}/reports/jacoco/report.xml")
             xml.enabled true
             html.enabled true
-            html.destination "${buildDir}/jacocoHtml"
+            html.destination file("${buildDir}/jacocoHtml")
         }
     }
 
@@ -104,16 +104,15 @@ repositories {
     }
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.0'
-}
+// task wrapper(type: Wrapper) {
+//     gradleVersion = '6.3'
+// }
 
 asciidoctor {
     //backends 'pdf'
     sourceDir = file('docs/source')
     outputDir = file('build/docs')
-    attributes   \
-             'VERSION': "$version",
+    attributes 'VERSION': "$version",
             'source-highlighter': 'coderay',
             'imagesdir': './images',
             'toc': 'left',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip

--- a/kirk-core/build.gradle
+++ b/kirk-core/build.gradle
@@ -1,8 +1,9 @@
 buildscript {
-    ext.kotlinVersion = '1.1.50'
+    ext.kotlinVersion = '1.3.72'
     ext.seleniumVersion = '3.141.59'
 
     repositories {
+        jcenter()
         mavenCentral()
     }
     dependencies {
@@ -11,15 +12,15 @@ buildscript {
 }
 
 dependencies {
-    compile "org.seleniumhq.selenium:selenium-java:$seleniumVersion"
-    compile "org.aeonbits.owner:owner-java8:1.0.9"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion"
-    compile "io.github.bonigarcia:webdrivermanager:3.7.1"
-    testCompile "org.testng:testng:6.11"
-    testCompile "me.tatarka.assertk:assertk:1.0-SNAPSHOT"
-    testCompile "org.eclipse.jetty:jetty-server:9.4.6.v20170531"
-    testCompile "org.eclipse.jetty:jetty-servlet:9.4.6.v20170531"
-    testCompile "org.seleniumhq.selenium:selenium-server:$seleniumVersion"
+    implementation "org.seleniumhq.selenium:selenium-java:$seleniumVersion"
+    implementation "org.aeonbits.owner:owner-java8:1.0.9"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    implementation "io.github.bonigarcia:webdrivermanager:3.7.1"
+    testImplementation "org.testng:testng:6.11"
+    testImplementation "me.tatarka.assertk:assertk:1.0-SNAPSHOT"
+    testImplementation "org.eclipse.jetty:jetty-server:9.4.6.v20170531"
+    testImplementation "org.eclipse.jetty:jetty-servlet:9.4.6.v20170531"
+    testImplementation "org.seleniumhq.selenium:selenium-server:$seleniumVersion"
 }
 
 compileKotlin {

--- a/kirk-core/src/main/kotlin/com/automation/remarks/kirk/core/WebDriverFactory.kt
+++ b/kirk-core/src/main/kotlin/com/automation/remarks/kirk/core/WebDriverFactory.kt
@@ -10,7 +10,9 @@ import org.openqa.selenium.WebDriver
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeOptions
 import org.openqa.selenium.firefox.FirefoxDriver
+import org.openqa.selenium.firefox.FirefoxOptions
 import org.openqa.selenium.ie.InternetExplorerDriver
+import org.openqa.selenium.ie.InternetExplorerOptions
 import org.openqa.selenium.remote.DesiredCapabilities
 import org.openqa.selenium.remote.RemoteWebDriver
 import java.net.URI
@@ -44,18 +46,21 @@ class WebDriverFactory {
 
     private fun createChromeDriver(): WebDriver {
         chromedriver().setup()
-        val capabilities = getCapabilities()
-        return ChromeDriver(capabilities.merge(getOptions()))
+        // val capabilities = getCapabilities()
+        // return ChromeDriver(capabilities.merge(getOptions()))
+        return ChromeDriver(ChromeOptions())
     }
 
     private fun createFireFoxDriver(): WebDriver {
         firefoxdriver().setup()
-        return FirefoxDriver(getCapabilities())
+        // return FirefoxDriver(getCapabilities())
+        return FirefoxDriver(FirefoxOptions())
     }
 
     private fun createInternetExplorerDriver(): WebDriver {
         iedriver().setup()
-        return InternetExplorerDriver(getCapabilities())
+        // return InternetExplorerDriver(getCapabilities())
+        return InternetExplorerDriver(InternetExplorerOptions())
     }
 
     private fun createRemoteDriver(browser: String): WebDriver {


### PR DESCRIPTION
and replaced Selenium Capabilities w/Options.

Using this library was lighting up my Build outputs with warnings of duplicated and depreciated Kotlin versions. I haven't modified or added any features, only attempted to suppress the warnings by upgrading to newer releases. The only code adjustment is instantiating the WebDrivers with Options, not Capabilities.